### PR TITLE
fix: Change not to replace when liveImageUrl is null

### DIFF
--- a/components/VideoCardContainer.tsx
+++ b/components/VideoCardContainer.tsx
@@ -6,7 +6,7 @@ export default function VideoCardContainer({ data }: { [key: string]: any }) {
     return (
         <div className="flex flex-col gap-3 p-2 w-1/2  md:w-1/3 lg:w-1/4 xl:w-1/5 box-border hover:scale-110 transition-transform">
             <a href={`https://chzzk.naver.com/live/${data.channel.channelId}`} className=" relative">
-                <img src={isLoading ? "/bg-video.png" : data.liveImageUrl.replace("{type}", "480")} onLoad={() => setIsLoading(false)} className="rounded-xl" />
+                <img src={isLoading ? "/bg-video.png" : data.liveImageUrl && data.liveImageUrl.replace("{type}", "480")} onLoad={() => setIsLoading(false)} className="rounded-xl" />
                 <div className="flex items-center absolute left-1.5 top-1.5 h-6 gap-2">
                     <span className="bg-red-600 rounded-sm pl-1 pr-1 text-white font-semibold py-0.5 h-4 text-sm leading-4">LIVE</span>
                     <span className="bg-black bg-opacity-80 rounded-sm pl-1 pr-1 text-white font-semibold py-0.5 h-4 text-sm leading-4">{data.concurrentUserCount}명 시청</span>

--- a/components/VideoCardContainer.tsx
+++ b/components/VideoCardContainer.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 
 export default function VideoCardContainer({ data }: { [key: string]: any }) {
     const [isLoading, setIsLoading] = useState(true);
+    const adultLiveImageUrl = 'https://ssl.pstatic.net/static/nng/glive/resource/p/static/media/image_age_restriction.c04b98f818ed01f04be9.png';
     return (
         <div className="flex flex-col gap-3 p-2 w-1/2  md:w-1/3 lg:w-1/4 xl:w-1/5 box-border hover:scale-110 transition-transform">
             <a href={`https://chzzk.naver.com/live/${data.channel.channelId}`} className=" relative">
-                <img src={isLoading ? "/bg-video.png" : data.liveImageUrl && data.liveImageUrl.replace("{type}", "480")} onLoad={() => setIsLoading(false)} className="rounded-xl" />
+                <img src={isLoading ? "/bg-video.png" : data.liveImageUrl ? data.liveImageUrl.replace("{type}", "480") : data.adult && adultLiveImageUrl } onLoad={() => setIsLoading(false)} className="rounded-xl" />
                 <div className="flex items-center absolute left-1.5 top-1.5 h-6 gap-2">
                     <span className="bg-red-600 rounded-sm pl-1 pr-1 text-white font-semibold py-0.5 h-4 text-sm leading-4">LIVE</span>
                     <span className="bg-black bg-opacity-80 rounded-sm pl-1 pr-1 text-white font-semibold py-0.5 h-4 text-sm leading-4">{data.concurrentUserCount}명 시청</span>


### PR DESCRIPTION
Relates to #1 

## 문제 상황 및 원인 파악
- JS 구문 오류가 발생하여 Client Side Exception이 발생하는 상황이었습니다.
- 로그의 replace 문에서 문제가 발생하였고, 코드 내에서 replace 문을 쓰는 부분은 한 군데였습니다.
- 썸네일이 존재하지 않을 때 해당 오류가 발생함을 확인하였고, 연령제한 방송 중일 경우 `data.liveImageUrl`이 넘어오지 않음을 확인하였습니다.

## 변경사항
- `data.liveImageUrl`이 존재하지 않으면 replace를 하지 않도록 수정했습니다.
- `data.adult` 값이 true이면 연령제한 썸네일을 띄우도록 수정했습니다.

## 수정사항 캡쳐
<img width="674" alt="스크린샷 2024-01-05 오후 7 28 23" src="https://github.com/axl0926/chzzk/assets/22076477/f027ea9f-f5c1-4063-ad2a-a9a129837f1e">
